### PR TITLE
Add Aspire.Hosting.NodeJs package

### DIFF
--- a/AspireSample/AspireSample.ApiService/AspireSample.ApiService.csproj
+++ b/AspireSample/AspireSample.ApiService/AspireSample.ApiService.csproj
@@ -19,6 +19,7 @@
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.1" />
+    <PackageReference Include="Aspire.Hosting.NodeJs" Version="9.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Include the old Aspire.Hosting.NodeJs package version 9.0.0 in the project dependencies.