### PR TITLE
Potential fix for code scanning alert no. 1: SQL query built from user-controlled sources

### DIFF
--- a/AspireSample/AspireSample.ApiService/PostalCodeEndpoint.cs
+++ b/AspireSample/AspireSample.ApiService/PostalCodeEndpoint.cs
@@ -12,8 +12,8 @@ namespace AspireSample.ApiService
     {
       app.MapGet("/badpostalcode/{postalcode}/{housenumber}", async (string postalcode, string housenumber, FedDbContext context) =>
       {
-        var sql = $"SELECT Id, Code, HouseNumber, City, StreetName FROM PostalCodes WHERE Code = '{postalcode}' AND HouseNumber = '{housenumber}'";
-        var result = context.PostalCodes.FromSqlRaw(sql).AsQueryable() is { } code
+        var sql = "SELECT Id, Code, HouseNumber, City, StreetName FROM PostalCodes WHERE Code = @postalcode AND HouseNumber = @housenumber";
+        var result = context.PostalCodes.FromSqlRaw(sql, new SqlParameter("@postalcode", postalcode), new SqlParameter("@housenumber", housenumber)).AsQueryable() is { } code
             ? Results.Ok(code)
             : Results.NotFound();
 


### PR DESCRIPTION
Potential fix for [https://github.com/avwolferen/fedevcontainer/security/code-scanning/1](https://github.com/avwolferen/fedevcontainer/security/code-scanning/1)

To fix the problem, we should use parameterized queries instead of string interpolation to construct the SQL query. This approach ensures that user input is treated as data and not executable code, thus preventing SQL injection attacks.

- Replace the string interpolation with a parameterized query using `FromSqlRaw` method with parameters.
- Modify the SQL query to include placeholders for the parameters.
- Add the parameters to the query using `SqlParameter`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
