### PR TITLE
Potential fix for code scanning alert no. 2: SQL query built from user-controlled sources

### DIFF
--- a/AspireSample/AspireSample.ApiService/RecipeEndpoint .cs
+++ b/AspireSample/AspireSample.ApiService/RecipeEndpoint .cs
@@ -12,8 +12,8 @@ namespace AspireSample.ApiService
     {
       app.MapGet("/badrecipe/{id}", async (string id, FedDbContext context) =>
       {
-        var sql = $"SELECT * FROM Recipes WHERE IsSecret = 0 and Id = '{id}'";
-        var result = context.Recipes.FromSqlRaw(sql).AsQueryable() is { } code
+        var sql = "SELECT * FROM Recipes WHERE IsSecret = 0 and Id = @id";
+        var result = context.Recipes.FromSqlRaw(sql, new SqlParameter("@id", id)).AsQueryable() is { } code
             ? Results.Ok(code)
             : Results.NotFound();
 


### PR DESCRIPTION
Potential fix for [https://github.com/avwolferen/fedevcontainer/security/code-scanning/2](https://github.com/avwolferen/fedevcontainer/security/code-scanning/2)

To fix the problem, we should use parameterized queries instead of string interpolation to construct the SQL query. This approach ensures that user input is treated as data rather than executable code, preventing SQL injection attacks.

- Replace the string interpolation with a parameterized query.
- Use `FromSqlRaw` with parameters to safely include the `id` in the query.
- Modify the code to add the necessary parameter to the query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
