### PR TITLE
Fix for Unnecessarily complex Boolean expression

### DIFF
--- a/AspireSample/AspireSample.ApiService/RecipeEndpoint .cs
+++ b/AspireSample/AspireSample.ApiService/RecipeEndpoint .cs
@@ -33,7 +33,7 @@ namespace AspireSample.ApiService
 
       app.MapGet("/recipes", async (string id, FedDbContext context) =>
       {
-        var result = context.Recipes.Where(r => r.IsSecret == false).AsQueryable() is { } code
+        var result = context.Recipes.Where(r => !r.IsSecret).AsQueryable() is { } code
             ? Results.Ok(code)
             : Results.NotFound();
 


### PR DESCRIPTION
To fix the problem, replace the unnecessarily complex boolean comparison `r.IsSecret == false` with the more idiomatic and readable `!r.IsSecret`. This should be done within the LINQ expression in the `/recipes` endpoint mapping in file AspireSample/AspireSample.ApiService/RecipeEndpoint .cs, specifically on line 36. No other changes are needed, and no new imports or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._